### PR TITLE
Fix incorrect usage of tag and add support for multiple tags

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,13 +57,12 @@ func postNostr(nsec string, rs []string, link string, content string) error {
 	ev.Kind = nostr.KindTextNote
 	ev.Tags = nostr.Tags{}
 	ev.Tags = ev.Tags.AppendUnique(nostr.Tag{"proxy", link, "rss"})
-	hashtag := nostr.Tag{"h"}
+
 	for _, m := range regexp.MustCompile(`#[^\s!@#$%^&*()=+.\/,\[{\]};:'"?><]+`).FindAllStringSubmatchIndex(ev.Content, -1) {
-		hashtag = append(hashtag, ev.Content[m[0]+1:m[1]])
-	}
-	if len(hashtag) > 1 {
+		hashtag := nostr.Tag{"t", ev.Content[m[0]+1 : m[1]]}
 		ev.Tags = ev.Tags.AppendUnique(hashtag)
 	}
+
 	ev.Sign(sk)
 
 	success := 0


### PR DESCRIPTION
Mattn-san, this PR fix the incorrect usage of tag or typo (using "h" instead of "t") and add support multiple tags in content.

Previously, command like `./feed2nostr -format '{{.Title}}{{"\n"}}{{.Link}} #news #politic'` will produce event as follows:
```
{
    "id": "event_id",
    "tags": [
        [
            "proxy",
            "https://example.org/?utm_source=rss&utm_medium=rss&utm_campaign=RSS",
            "rss"
        ],
        [
            "h",
            "news",
            "politic"
        ]
    ]
},
```

This PR will fix the event to become valid event (e.g. [nevent1qqst3u3rruzf2u49py0g0jrn7slnfnhuqgwnkfdn8ar3azwyqy38lwgnhe75v](https://nostr.com/nevent1qqst3u3rruzf2u49py0g0jrn7slnfnhuqgwnkfdn8ar3azwyqy38lwgnhe75v) )
```
{
    "id": "event_id",
    "tags": [
        [
            "proxy",
            "https://example.org/?utm_source=rss&utm_medium=rss&utm_campaign=RSS",
            "rss"
        ],
        [
            "t",
            "news"
        ],
        [
            "t",
            "politic"
        ]
    ]
}
```

Thank you.