### PR TITLE
Retry failed publishes

### DIFF
--- a/main.go
+++ b/main.go
@@ -289,6 +289,9 @@ func main() {
 		err = postNostr(nsec, rs, item.Link, content)
 		if err != nil {
 			log.Println(err)
+			if _, deleteErr := bundb.NewDelete().Model(&fi).WherePK().Exec(context.Background()); deleteErr != nil {
+				log.Println(deleteErr)
+			}
 			continue
 		}
 	}


### PR DESCRIPTION
Remove the feed item record when publishing to all relays fails so the item can be retried on the next run.