### PR TITLE
Handle feed items without GUIDs

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,6 +59,13 @@ func parseRelays(s string) []string {
 	return rs
 }
 
+func itemGUID(item *gofeed.Item) string {
+	if item.GUID != "" {
+		return item.GUID
+	}
+	return item.Link
+}
+
 func normalize(s string) string {
 	// Remove invisible Unicode characters and squeeze multiple newlines
 	s = regexp.MustCompile(`[\p{Cf}]`).ReplaceAllString(s, "")
@@ -256,7 +263,7 @@ func main() {
 
 		fi := Feed2Nostr{
 			Feed: feedURL,
-			GUID: item.GUID,
+			GUID: itemGUID(item),
 		}
 		_, err := bundb.NewInsert().Model(&fi).Exec(context.Background())
 		if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"reflect"
 	"testing"
+
+	"github.com/mmcdole/gofeed"
 )
 
 func TestExtractHashtags(t *testing.T) {
@@ -51,6 +53,33 @@ func TestParseRelays(t *testing.T) {
 			got := parseRelays(tt.in)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("parseRelays(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestItemGUID(t *testing.T) {
+	tests := []struct {
+		name string
+		item *gofeed.Item
+		want string
+	}{
+		{
+			name: "uses guid when present",
+			item: &gofeed.Item{GUID: "guid-1", Link: "https://example.com/post"},
+			want: "guid-1",
+		},
+		{
+			name: "falls back to link when guid is empty",
+			item: &gofeed.Item{Link: "https://example.com/post"},
+			want: "https://example.com/post",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := itemGUID(tt.item)
+			if got != tt.want {
+				t.Errorf("itemGUID(%+v) = %q, want %q", tt.item, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Use the item link as the stored identifier when a feed item does not provide a GUID, preventing later items in the same feed from being treated as duplicates of an empty GUID.