### PR TITLE
Reject non-nsec keys

### DIFF
--- a/main.go
+++ b/main.go
@@ -144,8 +144,10 @@ func htmlToText(s string) string {
 func postNostr(nsec string, rs []string, link string, content string) error {
 	ev := nostr.Event{}
 	var sk string
-	if _, s, err := nip19.Decode(nsec); err != nil {
+	if prefix, s, err := nip19.Decode(nsec); err != nil {
 		return err
+	} else if prefix != "nsec" {
+		return fmt.Errorf("expected nsec private key, got %s", prefix)
 	} else {
 		sk = s.(string)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/mmcdole/gofeed"
+	"github.com/nbd-wtf/go-nostr/nip19"
 )
 
 func TestExtractHashtags(t *testing.T) {
@@ -171,5 +173,20 @@ func TestHtmlToText(t *testing.T) {
 				t.Errorf("htmlToText(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestPostNostrRejectsNonNsecKeys(t *testing.T) {
+	nprofile, err := nip19.EncodeProfile("3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = postNostr(nprofile, nil, "https://example.com/post", "content")
+	if err == nil {
+		t.Fatal("postNostr returned nil error for nprofile key")
+	}
+	if !strings.Contains(err.Error(), "expected nsec private key") {
+		t.Fatalf("postNostr error = %q, want expected nsec private key", err)
 	}
 }


### PR DESCRIPTION
Return a clear error when the configured key is a NIP-19 value other than nsec, avoiding a panic from an invalid type assertion.