### PR TITLE
Ignore URL fragments in hashtags

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,13 +37,13 @@ type Feed2Nostr struct {
 	CreatedAt time.Time `bun:"created_at,notnull,default:current_timestamp" json:"created_at"`
 }
 
-var hashtagRE = regexp.MustCompile(`#[^\s!@#$%^&*()=+.\/,\[{\]};:'"?><]+`)
+var hashtagRE = regexp.MustCompile(`(^|\s)#([^\s!@#$%^&*()=+.\/,\[{\]};:'"?><]+)`)
 
 func extractHashtags(s string) []string {
-	matches := hashtagRE.FindAllStringSubmatchIndex(s, -1)
+	matches := hashtagRE.FindAllStringSubmatch(s, -1)
 	tags := make([]string, 0, len(matches))
 	for _, m := range matches {
-		tags = append(tags, s[m[0]+1:m[1]])
+		tags = append(tags, m[2])
 	}
 	return tags
 }

--- a/main_test.go
+++ b/main_test.go
@@ -21,6 +21,8 @@ func TestExtractHashtags(t *testing.T) {
 		{"japanese", "こんにちは #日本語 タグ", []string{"日本語"}},
 		{"stops at punctuation", "see #tag, then #next.", []string{"tag", "next"}},
 		{"stops at space", "#one #two", []string{"one", "two"}},
+		{"ignores url fragments", "see https://example.com/post#section #tag", []string{"tag"}},
+		{"ignores mid-word hash", "word#part #tag", []string{"tag"}},
 		{"hash only", "#", []string{}},
 		{"empty", "", []string{}},
 	}


### PR DESCRIPTION
Only extract hashtags at the start of content or after whitespace so URL fragments and mid-word hashes are not published as Nostr topic tags.