### PR TITLE
Handle event signing errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -170,7 +170,9 @@ func postNostr(nsec string, rs []string, link string, content string) error {
 		ev.Tags = ev.Tags.AppendUnique(nostr.Tag{"t", h})
 	}
 
-	ev.Sign(sk)
+	if err := ev.Sign(sk); err != nil {
+		return err
+	}
 
 	success := 0
 	ctx := context.Background()


### PR DESCRIPTION
Return signing failures from postNostr instead of ignoring them, preventing publish attempts with an event that could not be signed.