### PR TITLE
support NIP-29 group posting and NIP-42 auth via relay URL options

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -48,13 +50,35 @@ func extractHashtags(s string) []string {
 	return tags
 }
 
-func parseRelays(s string) []string {
-	var rs []string
+// relayOption is a relay URL with per-relay options parsed from its query
+// string, e.g. wss://example.communities.buzz.xyz?auth=true&group=xxx
+type relayOption struct {
+	URL   string
+	Auth  bool   // authenticate with NIP-42 before publishing
+	Group string // NIP-29 group id: post as kind 9 with an "h" tag
+}
+
+func parseRelays(s string) []relayOption {
+	var rs []relayOption
 	for _, r := range strings.Split(s, ",") {
 		r = strings.TrimSpace(r)
-		if r != "" {
-			rs = append(rs, r)
+		if r == "" {
+			continue
 		}
+		u, err := url.Parse(r)
+		if err != nil {
+			rs = append(rs, relayOption{URL: r})
+			continue
+		}
+		q := u.Query()
+		opt := relayOption{}
+		opt.Auth, _ = strconv.ParseBool(q.Get("auth"))
+		opt.Group = q.Get("group")
+		q.Del("auth")
+		q.Del("group")
+		u.RawQuery = q.Encode()
+		opt.URL = u.String()
+		rs = append(rs, opt)
 	}
 	return rs
 }
@@ -147,28 +171,21 @@ func htmlToText(s string) string {
 	return b.String()
 }
 
-func postNostr(nsec string, rs []string, link string, content string) error {
+// buildEvent constructs and signs the event for one relay configuration. A
+// plain relay gets a kind 1 note; a relay with a group gets a kind 9 NIP-29
+// group message carrying the group id in the "h" tag.
+func buildEvent(sk string, pub string, link string, content string, group string) (*nostr.Event, error) {
 	ev := nostr.Event{}
-	var sk string
-	if prefix, s, err := nip19.Decode(nsec); err != nil {
-		return err
-	} else if prefix != "nsec" {
-		return fmt.Errorf("expected nsec private key, got %s", prefix)
-	} else {
-		sk = s.(string)
-	}
-	if pub, err := nostr.GetPublicKey(sk); err == nil {
-		if _, err := nip19.EncodePublicKey(pub); err != nil {
-			return err
-		}
-		ev.PubKey = pub
-	} else {
-		return err
-	}
+	ev.PubKey = pub
 	ev.Content = content
 	ev.CreatedAt = nostr.Now()
-	ev.Kind = nostr.KindTextNote
 	ev.Tags = nostr.Tags{}
+	if group != "" {
+		ev.Kind = nostr.KindSimpleGroupChatMessage
+		ev.Tags = ev.Tags.AppendUnique(nostr.Tag{"h", group})
+	} else {
+		ev.Kind = nostr.KindTextNote
+	}
 	ev.Tags = ev.Tags.AppendUnique(nostr.Tag{"proxy", link, "rss"})
 	ev.Tags = ev.Tags.AppendUnique(nostr.Tag{"client", name})
 
@@ -177,18 +194,60 @@ func postNostr(nsec string, rs []string, link string, content string) error {
 	}
 
 	if err := ev.Sign(sk); err != nil {
+		return nil, err
+	}
+	return &ev, nil
+}
+
+func postNostr(nsec string, rs []relayOption, link string, content string) error {
+	var sk string
+	if prefix, s, err := nip19.Decode(nsec); err != nil {
+		return err
+	} else if prefix != "nsec" {
+		return fmt.Errorf("expected nsec private key, got %s", prefix)
+	} else {
+		sk = s.(string)
+	}
+	pub, err := nostr.GetPublicKey(sk)
+	if err != nil {
+		return err
+	}
+	if _, err := nip19.EncodePublicKey(pub); err != nil {
 		return err
 	}
 
+	events := map[string]*nostr.Event{}
 	success := 0
 	ctx := context.Background()
 	for _, r := range rs {
-		relay, err := nostr.RelayConnect(context.Background(), r)
+		ev, ok := events[r.Group]
+		if !ok {
+			ev, err = buildEvent(sk, pub, link, content, r.Group)
+			if err != nil {
+				return err
+			}
+			events[r.Group] = ev
+		}
+		relay, err := nostr.RelayConnect(context.Background(), r.URL)
 		if err != nil {
-			log.Printf("%v: %v", r, err)
+			log.Printf("%v: %v", r.URL, err)
 			continue
 		}
-		err = relay.Publish(ctx, ev)
+		if r.Auth {
+			// The relay sends its NIP-42 challenge unsolicited right after the
+			// connection opens; replying before it lands sends an empty
+			// challenge, which some relays treat as a hard failure.
+			time.Sleep(time.Second)
+			actx, cancel := context.WithTimeout(ctx, 3*time.Second)
+			err = relay.Auth(actx, func(aev *nostr.Event) error {
+				return aev.Sign(sk)
+			})
+			cancel()
+			if err != nil {
+				log.Printf("%v: auth: %v", r.URL, err)
+			}
+		}
+		err = relay.Publish(ctx, *ev)
 		relay.Close()
 		if err == nil {
 			success++
@@ -209,7 +268,7 @@ func main() {
 	var re *regexp.Regexp
 	var nsec string
 	var relays string
-	var rs []string
+	var rs []relayOption
 	var ver bool
 
 	flag.BoolVar(&skip, "skip", false, "Skip post")
@@ -218,7 +277,7 @@ func main() {
 	flag.StringVar(&format, "format", "{{.Title | normalize}}\n{{.Link}}", "Post Format")
 	flag.StringVar(&pattern, "pattern", "", "Match pattern")
 	flag.StringVar(&nsec, "nsec", os.Getenv("FEED2NOSTR_NSEC"), "Nostr nsec")
-	flag.StringVar(&relays, "relays", os.Getenv("FEED2NOSTR_RELAYS"), "Nostr relays")
+	flag.StringVar(&relays, "relays", os.Getenv("FEED2NOSTR_RELAYS"), "Nostr relays (per-relay options as query params: ?auth=true&group=xxx)")
 	flag.BoolVar(&ver, "v", false, "show version")
 	flag.Parse()
 

--- a/main_test.go
+++ b/main_test.go
@@ -43,14 +43,39 @@ func TestParseRelays(t *testing.T) {
 	tests := []struct {
 		name string
 		in   string
-		want []string
+		want []relayOption
 	}{
-		{"single", "wss://relay.example.com", []string{"wss://relay.example.com"}},
-		{"multiple", "wss://a.com,wss://b.com", []string{"wss://a.com", "wss://b.com"}},
-		{"with spaces", " wss://a.com , wss://b.com ", []string{"wss://a.com", "wss://b.com"}},
-		{"empty entries skipped", "wss://a.com,,wss://b.com", []string{"wss://a.com", "wss://b.com"}},
+		{"single", "wss://relay.example.com", []relayOption{{URL: "wss://relay.example.com"}}},
+		{"multiple", "wss://a.com,wss://b.com", []relayOption{{URL: "wss://a.com"}, {URL: "wss://b.com"}}},
+		{"with spaces", " wss://a.com , wss://b.com ", []relayOption{{URL: "wss://a.com"}, {URL: "wss://b.com"}}},
+		{"empty entries skipped", "wss://a.com,,wss://b.com", []relayOption{{URL: "wss://a.com"}, {URL: "wss://b.com"}}},
 		{"empty string", "", nil},
 		{"only commas and spaces", " , , ", nil},
+		{
+			"auth and group",
+			"wss://vim-jp.communities.buzz.xyz?auth=true&group=xxx",
+			[]relayOption{{URL: "wss://vim-jp.communities.buzz.xyz", Auth: true, Group: "xxx"}},
+		},
+		{
+			"group only",
+			"wss://a.com?group=yyy",
+			[]relayOption{{URL: "wss://a.com", Group: "yyy"}},
+		},
+		{
+			"auth false",
+			"wss://a.com?auth=false",
+			[]relayOption{{URL: "wss://a.com"}},
+		},
+		{
+			"mixed plain and group",
+			"wss://a.com,wss://b.com?auth=1&group=zzz",
+			[]relayOption{{URL: "wss://a.com"}, {URL: "wss://b.com", Auth: true, Group: "zzz"}},
+		},
+		{
+			"unrelated query params kept",
+			"wss://a.com?auth=true&foo=bar",
+			[]relayOption{{URL: "wss://a.com?foo=bar", Auth: true}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Lets feed2nostr deliver feeds into NIP-29 relay-based groups such as Buzz (buzz.xyz). Options are specified per relay as query parameters on the relay URL, so a single bot can post kind 1 notes to normal relays and kind 9 group messages to a Buzz relay at the same time:

```
-relays 'wss://yabu.me,wss://vim-jp.communities.buzz.xyz?auth=true&group=xxx'
```

- `group=<id>` — post to this relay as kind 9 (`KindSimpleGroupChatMessage`) with an `["h", <id>]` tag instead of kind 1
- `auth=true` — authenticate to this relay with NIP-42 before publishing; waits a second for the relay's unsolicited AUTH challenge (replying earlier sends an empty challenge, which some relays treat as a hard failure)

The `auth`/`group` parameters are stripped from the URL before connecting; other query parameters are kept. Events are built and signed once per distinct group value.

The bot's key must already be a member of the group for closed groups.